### PR TITLE
Linguist override Mathematica

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+resources/* linguist-vendored
+external/* linguist-vendored
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build*/
+.idea*/


### PR DESCRIPTION
Exclude `resources/*` and `external/*` files from GitHub's language statistics. 

Also added `.idea/` to `gitignore`.