### PR TITLE
clang-tidy code style cleanup

### DIFF
--- a/src/speed_of_sound.cc
+++ b/src/speed_of_sound.cc
@@ -2,160 +2,150 @@
 #include "speed_of_sound.h"
 
 namespace speedofsound {
-  Environment::Environment() {
-    temperature_ = theory::kStdTemperature;
-    humidity_ = theory::kStdHumidity;
-    pressure_ = theory::kStdPressure;
-    co2_mole_fraction_ = theory::kStdCO2MoleFraction;
-  }
+Environment::Environment() {
+  temperature_ = theory::kStdTemperature;
+  humidity_ = theory::kStdHumidity;
+  pressure_ = theory::kStdPressure;
+  co2_mole_fraction_ = theory::kStdCO2MoleFraction;
+}
 
-  bool Environment::ValidateTemperature() const {
-    return theory::kMinTemperature <= temperature_ &&
-      temperature_ <= theory::kMaxTemperature;
-  }
+bool Environment::ValidateTemperature() const {
+  return theory::kMinTemperature <= temperature_ &&
+         temperature_ <= theory::kMaxTemperature;
+}
 
-  bool Environment::ValidateHumidity() const {
-    return theory::kMinHumidity <= humidity_ &&
-      humidity_ <= theory::kMaxHumidity;
-  }
+bool Environment::ValidateHumidity() const {
+  return theory::kMinHumidity <= humidity_ && humidity_ <= theory::kMaxHumidity;
+}
 
-  bool Environment::ValidatePressure() const {
-    return theory::kMinPressure <= pressure_ &&
-      pressure_ <= theory::kMaxPressure;
-  }
+bool Environment::ValidatePressure() const {
+  return theory::kMinPressure <= pressure_ && pressure_ <= theory::kMaxPressure;
+}
 
-  bool Environment::ValidateCO2MoleFraction() const {
-    return theory::kMinCO2MoleFraction <= co2_mole_fraction_ &&
-      co2_mole_fraction_ <= theory::kMaxCO2MoleFraction;
-  }
+bool Environment::ValidateCO2MoleFraction() const {
+  return theory::kMinCO2MoleFraction <= co2_mole_fraction_ &&
+         co2_mole_fraction_ <= theory::kMaxCO2MoleFraction;
+}
 
-  bool Environment::ValidateEnvironment() const {
-    return ValidateTemperature() &&
-      ValidateHumidity() &&
-      ValidatePressure() &&
-      ValidateCO2MoleFraction();
-  }
+bool Environment::ValidateEnvironment() const {
+  return ValidateTemperature() && ValidateHumidity() && ValidatePressure() &&
+         ValidateCO2MoleFraction();
+}
 
+EnvironmentRate::EnvironmentRate() {
+  temperature_rate_ = 0.0;
+  humidity_rate_ = 0.0;
+  pressure_rate_ = 0.0;
+  co2_mole_fraction_rate_ = 0.0;
+}
 
-  EnvironmentRate::EnvironmentRate() {
-    temperature_rate_ = 0.0;
-    humidity_rate_ = 0.0;
-    pressure_rate_ = 0.0;
-    co2_mole_fraction_rate_ = 0.0;
-  }
+SpeedOfSound::SpeedOfSound() { SpeedOfSound::Compute(init_environment); }
 
+SpeedOfSound::SpeedOfSound(Environment &ambient_conitions) {
+  init_environment.temperature_ = ambient_conitions.temperature_;
+  init_environment.humidity_ = ambient_conitions.humidity_;
+  init_environment.pressure_ = ambient_conitions.pressure_;
+  init_environment.co2_mole_fraction_ = ambient_conitions.co2_mole_fraction_;
 
-  SpeedOfSound::SpeedOfSound() {
-    SpeedOfSound::Compute(init_environment);
-  }
+  SpeedOfSound::Compute(init_environment);
+}
 
+Environment SpeedOfSound::GetInitEnvironment() const {
+  return init_environment;
+}
 
-  SpeedOfSound::SpeedOfSound(Environment &ambient_conitions) {
-    init_environment.temperature_ = ambient_conitions.temperature_;
-    init_environment.humidity_ = ambient_conitions.humidity_;
-    init_environment.pressure_ = ambient_conitions.pressure_;
-    init_environment.co2_mole_fraction_ = ambient_conitions.co2_mole_fraction_;
+EnvironmentRate SpeedOfSound::GetInitEnvironmentRate() const {
+  return init_environment_rate;
+}
 
-    SpeedOfSound::Compute(init_environment);
-  }
-
-  Environment SpeedOfSound::GetInitEnvironment() const {
-    return init_environment;
-  }
-
-  EnvironmentRate SpeedOfSound::GetInitEnvironmentRate() const {
-    return init_environment_rate;
-  }
-
-  double SpeedOfSound::Compute(Environment &ambient_conitions) {
-    double t, h, p, xc, T, F, Psv, Xw, C, dF_dt, dF_dp, dPsv_dt, dXw_dF, dC_dXw,
+double SpeedOfSound::Compute(Environment &ambient_conitions) {
+  double t, h, p, xc, T, F, Psv, Xw, C, dF_dt, dF_dp, dPsv_dt, dXw_dF, dC_dXw,
       dXw_dPsv, dXw_dp, dXw_dh, dC_dt, dC_dxc, dC_dp, dC_dh;
 
-    t  = ambient_conitions.temperature_;
-    h  = ambient_conitions.humidity_;
-    p  = ambient_conitions.pressure_;
-    xc = ambient_conitions.co2_mole_fraction_;
+  t = ambient_conitions.temperature_;
+  h = ambient_conitions.humidity_;
+  p = ambient_conitions.pressure_;
+  xc = ambient_conitions.co2_mole_fraction_;
 
-    T        = theory::T(t);
-    F        = theory::F(p, t);
-    Psv      = theory::Psv(T);
-    Xw       = theory::Xw(h, F, Psv, p);
-    C        = theory::C(t, p, Xw, xc);
-    dF_dt    = theory::dF_dt(t);
-    dF_dp    = theory::dF_dp();
-    dPsv_dt  = theory::dPsv_dt(T);
-    dXw_dF   = theory::dXw_dF(h, Psv, p);
-    dXw_dPsv = theory::dXw_dPsv(h, F, p);
-    dXw_dp   = theory::dXw_dp(h, F, Psv, p);
-    dXw_dh   = theory::dXw_dh(F, Psv, p);
-    dC_dt    = theory::dC_dt(t, p, Xw, xc, dXw_dF, dF_dt, dXw_dPsv, dPsv_dt);
-    dC_dxc   = theory::dC_dxc(t, p, Xw, xc);
-    dC_dp    = theory::dC_dp(t, p, Xw, xc, dXw_dp);
-    dC_dXw   = theory::dC_dXw(t, p, Xw, xc);
-    dC_dh    = theory::dC_dh(dC_dXw, dXw_dh);
+  T = theory::T(t);
+  F = theory::F(p, t);
+  Psv = theory::Psv(T);
+  Xw = theory::Xw(h, F, Psv, p);
+  C = theory::C(t, p, Xw, xc);
+  dF_dt = theory::dF_dt(t);
+  dF_dp = theory::dF_dp();
+  dPsv_dt = theory::dPsv_dt(T);
+  dXw_dF = theory::dXw_dF(h, Psv, p);
+  dXw_dPsv = theory::dXw_dPsv(h, F, p);
+  dXw_dp = theory::dXw_dp(h, F, Psv, p);
+  dXw_dh = theory::dXw_dh(F, Psv, p);
+  dC_dt = theory::dC_dt(t, p, Xw, xc, dXw_dF, dF_dt, dXw_dPsv, dPsv_dt);
+  dC_dxc = theory::dC_dxc(t, p, Xw, xc);
+  dC_dp = theory::dC_dp(t, p, Xw, xc, dXw_dp);
+  dC_dXw = theory::dC_dXw(t, p, Xw, xc);
+  dC_dh = theory::dC_dh(dC_dXw, dXw_dh);
 
-    init_speed_of_sound_ = C;
+  init_speed_of_sound_ = C;
 
-    init_environment.temperature_ = t;
-    init_environment.humidity_ = h;
-    init_environment.pressure_ = p;
-    init_environment.co2_mole_fraction_ = xc;
+  init_environment.temperature_ = t;
+  init_environment.humidity_ = h;
+  init_environment.pressure_ = p;
+  init_environment.co2_mole_fraction_ = xc;
 
-    init_environment_rate.temperature_rate_ = dC_dt;
-    init_environment_rate.humidity_rate_ = dC_dh;
-    init_environment_rate.pressure_rate_ = dC_dp;
-    init_environment_rate.co2_mole_fraction_rate_ = dC_dxc;
+  init_environment_rate.temperature_rate_ = dC_dt;
+  init_environment_rate.humidity_rate_ = dC_dh;
+  init_environment_rate.pressure_rate_ = dC_dp;
+  init_environment_rate.co2_mole_fraction_rate_ = dC_dxc;
 
-    return init_speed_of_sound_;
-  }
-
-
-  double SpeedOfSound::QuickCompute(Environment &ambient_conitions) const {
-    double t, h, p, xc, T, F, Psv, Xw;
-
-    t  = ambient_conitions.temperature_;
-    h  = ambient_conitions.humidity_;
-    p  = ambient_conitions.pressure_;
-    xc = ambient_conitions.co2_mole_fraction_;
-
-    T   = theory::T(t);
-    F   = theory::F(p, t);
-    Psv = theory::Psv(T);
-    Xw  = theory::Xw(h, F, Psv, p);
-
-    return theory::C(t, p, Xw, xc);
-  }
-
-
-  double SpeedOfSound::Approximate(Environment &ambient_conitions) const {
-    double approx_speed_of_sound, speed_of_sound_change;
-    approx_speed_of_sound = init_speed_of_sound_;
-
-    if (ambient_conitions.temperature_ != init_environment.temperature_) {
-      speed_of_sound_change  = ambient_conitions.temperature_;
-      speed_of_sound_change -= init_environment.temperature_;
-      speed_of_sound_change *= init_environment_rate.temperature_rate_;
-      approx_speed_of_sound += speed_of_sound_change;
-    }
-    if (ambient_conitions.humidity_ != init_environment.humidity_) {
-      speed_of_sound_change  = ambient_conitions.humidity_;
-      speed_of_sound_change -= init_environment.humidity_;
-      speed_of_sound_change *= init_environment_rate.humidity_rate_;
-      approx_speed_of_sound += speed_of_sound_change;
-    }
-    if (ambient_conitions.pressure_ != init_environment.pressure_) {
-      speed_of_sound_change  = ambient_conitions.pressure_;
-      speed_of_sound_change -= init_environment.pressure_;
-      speed_of_sound_change *= init_environment_rate.pressure_rate_;
-      approx_speed_of_sound += speed_of_sound_change;
-    }
-    if (ambient_conitions.co2_mole_fraction_ != init_environment.co2_mole_fraction_) {
-      speed_of_sound_change  = ambient_conitions.co2_mole_fraction_;
-      speed_of_sound_change -= init_environment.co2_mole_fraction_;
-      speed_of_sound_change *= init_environment_rate.co2_mole_fraction_rate_;
-      approx_speed_of_sound += speed_of_sound_change;
-    }
-
-    return approx_speed_of_sound;
-  }
+  return init_speed_of_sound_;
 }
+
+double SpeedOfSound::QuickCompute(Environment &ambient_conitions) const {
+  double t, h, p, xc, T, F, Psv, Xw;
+
+  t = ambient_conitions.temperature_;
+  h = ambient_conitions.humidity_;
+  p = ambient_conitions.pressure_;
+  xc = ambient_conitions.co2_mole_fraction_;
+
+  T = theory::T(t);
+  F = theory::F(p, t);
+  Psv = theory::Psv(T);
+  Xw = theory::Xw(h, F, Psv, p);
+
+  return theory::C(t, p, Xw, xc);
+}
+
+double SpeedOfSound::Approximate(Environment &ambient_conitions) const {
+  double approx_speed_of_sound, speed_of_sound_change;
+  approx_speed_of_sound = init_speed_of_sound_;
+
+  if (ambient_conitions.temperature_ != init_environment.temperature_) {
+    speed_of_sound_change = ambient_conitions.temperature_;
+    speed_of_sound_change -= init_environment.temperature_;
+    speed_of_sound_change *= init_environment_rate.temperature_rate_;
+    approx_speed_of_sound += speed_of_sound_change;
+  }
+  if (ambient_conitions.humidity_ != init_environment.humidity_) {
+    speed_of_sound_change = ambient_conitions.humidity_;
+    speed_of_sound_change -= init_environment.humidity_;
+    speed_of_sound_change *= init_environment_rate.humidity_rate_;
+    approx_speed_of_sound += speed_of_sound_change;
+  }
+  if (ambient_conitions.pressure_ != init_environment.pressure_) {
+    speed_of_sound_change = ambient_conitions.pressure_;
+    speed_of_sound_change -= init_environment.pressure_;
+    speed_of_sound_change *= init_environment_rate.pressure_rate_;
+    approx_speed_of_sound += speed_of_sound_change;
+  }
+  if (ambient_conitions.co2_mole_fraction_ !=
+      init_environment.co2_mole_fraction_) {
+    speed_of_sound_change = ambient_conitions.co2_mole_fraction_;
+    speed_of_sound_change -= init_environment.co2_mole_fraction_;
+    speed_of_sound_change *= init_environment_rate.co2_mole_fraction_rate_;
+    approx_speed_of_sound += speed_of_sound_change;
+  }
+
+  return approx_speed_of_sound;
+}
+}  // namespace speedofsound

--- a/src/speed_of_sound.h
+++ b/src/speed_of_sound.h
@@ -5,38 +5,38 @@
 #define SPEED_OF_SOUND_H_
 
 namespace speedofsound {
-  class Environment {
-    public:
-      Environment();
-      bool ValidateTemperature() const;
-      bool ValidateHumidity() const;
-      bool ValidatePressure() const;
-      bool ValidateCO2MoleFraction() const;
-      bool ValidateEnvironment() const;
-      double temperature_, humidity_, pressure_, co2_mole_fraction_;
-  };
-  class EnvironmentRate {
-    public:
-      EnvironmentRate();
-      double temperature_rate_, humidity_rate_, pressure_rate_, co2_mole_fraction_rate_;
-  };
+class Environment {
+ public:
+  Environment();
+  bool ValidateTemperature() const;
+  bool ValidateHumidity() const;
+  bool ValidatePressure() const;
+  bool ValidateCO2MoleFraction() const;
+  bool ValidateEnvironment() const;
+  double temperature_, humidity_, pressure_, co2_mole_fraction_;
+};
+class EnvironmentRate {
+ public:
+  EnvironmentRate();
+  double temperature_rate_, humidity_rate_, pressure_rate_,
+      co2_mole_fraction_rate_;
+};
 
+class SpeedOfSound {
+ public:
+  SpeedOfSound();
+  SpeedOfSound(Environment &ambient_conitions);
+  Environment GetInitEnvironment() const;
+  EnvironmentRate GetInitEnvironmentRate() const;
+  double Compute(Environment &ambient_conitions);
+  double QuickCompute(Environment &ambient_conitions) const;
+  double Approximate(Environment &ambient_conitions) const;
 
-  class SpeedOfSound {
-    public:
-      SpeedOfSound();
-      SpeedOfSound(Environment &ambient_conitions);
-      Environment GetInitEnvironment() const;
-      EnvironmentRate GetInitEnvironmentRate() const;
-      double Compute(Environment &ambient_conitions);
-      double QuickCompute(Environment &ambient_conitions) const;
-      double Approximate(Environment &ambient_conitions) const;
-
-    private:
-      double init_speed_of_sound_;
-      Environment init_environment;
-      EnvironmentRate init_environment_rate;
-  };
-}
+ private:
+  double init_speed_of_sound_;
+  Environment init_environment;
+  EnvironmentRate init_environment_rate;
+};
+}  // namespace speedofsound
 
 #endif

--- a/src/speed_of_sound_theory.cc
+++ b/src/speed_of_sound_theory.cc
@@ -2,129 +2,106 @@
 #include "speed_of_sound_theory.h"
 
 namespace speedofsound {
-  namespace theory {
-    double T(double t) {
-      return t + 273.15;
-    }
+namespace theory {
+double T(double t) { return t + 273.15; }
 
-    double dT_dt() {
-      return 1.0;
-    }
+double dT_dt() { return 1.0; }
 
+double F(double p, double t) { return k16 + k17 * p + k18 * t * t; }
 
-    double F(double p, double t) {
-      return k16 + k17 * p + k18 * t * t;
-    }
+double dF_dp() { return k17; }
 
-    double dF_dp() {
-      return k17;
-    }
+double dF_dt(double t) { return 2 * k18 * t; }
 
-    double dF_dt(double t) {
-      return 2 * k18 * t;
-    }
-
-
-    double Psv(double T) {
-      double Psv;
-      Psv  = k19 * T * T;
-      Psv += k20 * T;
-      Psv += k21;
-      Psv += k22 / T;
-      Psv  = exp(Psv);
-      return Psv;
-    }
-
-    double dPsv_dt(double T) {
-      double dPsv_dt;
-      dPsv_dt  = 2 * k19 * T + k20 - k22 / (T * T);
-      dPsv_dt *= Psv(T);
-      dPsv_dt *= dT_dt();
-      return dPsv_dt;
-    }
-
-
-    double Xw(double h, double F, double Psv, double p) {
-      return h * F * Psv / p;
-    }
-
-    double dXw_dh(double F, double Psv, double p) {
-      return F * Psv / p;
-    }
-
-    double dXw_dF(double h, double Psv, double p) {
-      return h * Psv / p;
-    }
-
-    double dXw_dPsv(double h, double F, double p) {
-      return h * F / p;
-    }
-
-    double dXw_dp(double h, double F, double Psv, double p) {
-      double dXw_dp;
-      dXw_dp  = -h * F * Psv / (p * p);
-      dXw_dp += h * dF_dp() * Psv / p;
-      return dXw_dp;
-    }
-
-
-    double C(double t, double p, double Xw, double xc) {
-      double C;
-      C  =  k00 + k01 * t + k02 * t * t;
-      C += (k03 + k04 * t + k05 * t * t) * Xw;
-      C += (k06 + k07 * t + k08 * t * t) * p;
-      C += (k09 + k10 * t + k11 * t * t) * xc;
-      C +=  k12 * Xw  * Xw;
-      C +=  k13 * p   * p;
-      C +=  k14 * xc  * xc;
-      C +=  k15 * Xw  * p * xc;
-      return C;
-    }
-
-    double dC_dt(double t, double p, double Xw, double xc, double dXw_dF, double dF_dt, double dXw_dPsv, double dPsv_dt) {
-      double dC_dt;
-      dC_dt  =  k01 + 2 * k02 * t;
-      dC_dt += (k04 + 2 * k05 * t) * Xw;
-      dC_dt += (k03 + k04 * t + k05 * t * t) * dXw_dPsv * dPsv_dt;
-      dC_dt += (k03 + k04 * t + k05 * t * t) * dXw_dF * dF_dt;
-      dC_dt += (k07 + 2 * k08 * t) * p;
-      dC_dt += (k10 + 2 * k11 * t) * xc;
-      dC_dt += 2 * k12 * Xw * dXw_dPsv * dPsv_dt;
-      dC_dt += 2 * k12 * Xw * dXw_dF * dF_dt;
-      dC_dt += k15 * p * xc * dXw_dPsv * dPsv_dt;
-      dC_dt += k15 * p * xc * dXw_dF * dF_dt;
-      return dC_dt;
-    }
-
-    double dC_dXw(double t, double p, double Xw, double xc) {
-      double dC_dXw;
-      dC_dXw  = k03 + k04 * t + k05 * t * t;
-      dC_dXw += 2 * k12 * Xw;
-      dC_dXw += k15 * xc * p;
-      return dC_dXw;
-    }
-
-    double dC_dp(double t, double p, double Xw, double xc, double dXw_dp) {
-      double dC_dp;
-      dC_dp  = (k03 + k04 * t + k05 * t * t) * dXw_dp;
-      dC_dp += k06 + k07 * t + k08 * t * t;
-      dC_dp += 2 * k12 * Xw * dXw_dp;
-      dC_dp += 2 * k13 * p;
-      dC_dp += k15 * dXw_dp * p * xc;
-      dC_dp += k15 * Xw * xc;
-      return dC_dp;
-    }
-
-    double dC_dxc(double t, double p, double Xw, double xc) {
-      double dC_dxc;
-      dC_dxc  = k09 + k10 * t + k11 * t * t;
-      dC_dxc += 2 * k14 * xc;
-      dC_dxc += k15 * p * Xw;
-      return dC_dxc;
-    }
-
-    double dC_dh(double dC_dXw, double dXw_dh) {
-      return dC_dXw * dXw_dh;
-    }
-  }
+double Psv(double T) {
+  double Psv;
+  Psv = k19 * T * T;
+  Psv += k20 * T;
+  Psv += k21;
+  Psv += k22 / T;
+  Psv = exp(Psv);
+  return Psv;
 }
+
+double dPsv_dt(double T) {
+  double dPsv_dt;
+  dPsv_dt = 2 * k19 * T + k20 - k22 / (T * T);
+  dPsv_dt *= Psv(T);
+  dPsv_dt *= dT_dt();
+  return dPsv_dt;
+}
+
+double Xw(double h, double F, double Psv, double p) { return h * F * Psv / p; }
+
+double dXw_dh(double F, double Psv, double p) { return F * Psv / p; }
+
+double dXw_dF(double h, double Psv, double p) { return h * Psv / p; }
+
+double dXw_dPsv(double h, double F, double p) { return h * F / p; }
+
+double dXw_dp(double h, double F, double Psv, double p) {
+  double dXw_dp;
+  dXw_dp = -h * F * Psv / (p * p);
+  dXw_dp += h * dF_dp() * Psv / p;
+  return dXw_dp;
+}
+
+double C(double t, double p, double Xw, double xc) {
+  double C;
+  C = k00 + k01 * t + k02 * t * t;
+  C += (k03 + k04 * t + k05 * t * t) * Xw;
+  C += (k06 + k07 * t + k08 * t * t) * p;
+  C += (k09 + k10 * t + k11 * t * t) * xc;
+  C += k12 * Xw * Xw;
+  C += k13 * p * p;
+  C += k14 * xc * xc;
+  C += k15 * Xw * p * xc;
+  return C;
+}
+
+double dC_dt(double t, double p, double Xw, double xc, double dXw_dF,
+             double dF_dt, double dXw_dPsv, double dPsv_dt) {
+  double dC_dt;
+  dC_dt = k01 + 2 * k02 * t;
+  dC_dt += (k04 + 2 * k05 * t) * Xw;
+  dC_dt += (k03 + k04 * t + k05 * t * t) * dXw_dPsv * dPsv_dt;
+  dC_dt += (k03 + k04 * t + k05 * t * t) * dXw_dF * dF_dt;
+  dC_dt += (k07 + 2 * k08 * t) * p;
+  dC_dt += (k10 + 2 * k11 * t) * xc;
+  dC_dt += 2 * k12 * Xw * dXw_dPsv * dPsv_dt;
+  dC_dt += 2 * k12 * Xw * dXw_dF * dF_dt;
+  dC_dt += k15 * p * xc * dXw_dPsv * dPsv_dt;
+  dC_dt += k15 * p * xc * dXw_dF * dF_dt;
+  return dC_dt;
+}
+
+double dC_dXw(double t, double p, double Xw, double xc) {
+  double dC_dXw;
+  dC_dXw = k03 + k04 * t + k05 * t * t;
+  dC_dXw += 2 * k12 * Xw;
+  dC_dXw += k15 * xc * p;
+  return dC_dXw;
+}
+
+double dC_dp(double t, double p, double Xw, double xc, double dXw_dp) {
+  double dC_dp;
+  dC_dp = (k03 + k04 * t + k05 * t * t) * dXw_dp;
+  dC_dp += k06 + k07 * t + k08 * t * t;
+  dC_dp += 2 * k12 * Xw * dXw_dp;
+  dC_dp += 2 * k13 * p;
+  dC_dp += k15 * dXw_dp * p * xc;
+  dC_dp += k15 * Xw * xc;
+  return dC_dp;
+}
+
+double dC_dxc(double t, double p, double Xw, double xc) {
+  double dC_dxc;
+  dC_dxc = k09 + k10 * t + k11 * t * t;
+  dC_dxc += 2 * k14 * xc;
+  dC_dxc += k15 * p * Xw;
+  return dC_dxc;
+}
+
+double dC_dh(double dC_dXw, double dXw_dh) { return dC_dXw * dXw_dh; }
+}  // namespace theory
+}  // namespace speedofsound

--- a/src/speed_of_sound_theory.h
+++ b/src/speed_of_sound_theory.h
@@ -5,71 +5,72 @@
 #define SPEED_OF_SOUND_THEORY_H_
 
 namespace speedofsound {
-  namespace theory {
-    static constexpr double kStdTemperature = 20.0;
-    static constexpr double kStdHumidity = 0.5;
-    static constexpr double kStdPressure = 101325.0;
-    static constexpr double kStdCO2MoleFraction = 0.000314;
+namespace theory {
+static constexpr double kStdTemperature = 20.0;
+static constexpr double kStdHumidity = 0.5;
+static constexpr double kStdPressure = 101325.0;
+static constexpr double kStdCO2MoleFraction = 0.000314;
 
-    static constexpr double kMinTemperature = 0.0;
-    static constexpr double kMinHumidity = 0.0;
-    static constexpr double kMinPressure = 75000.0;
-    static constexpr double kMinXwPressure = 60000.0;
-    static constexpr double kMinCO2MoleFraction = 0.0;
+static constexpr double kMinTemperature = 0.0;
+static constexpr double kMinHumidity = 0.0;
+static constexpr double kMinPressure = 75000.0;
+static constexpr double kMinXwPressure = 60000.0;
+static constexpr double kMinCO2MoleFraction = 0.0;
 
-    static constexpr double kMaxTemperature = 30.0;
-    static constexpr double kMaxHumidity = 1.0;
-    static constexpr double kMaxPressure = 102000.0;
-    static constexpr double kMaxXwPressure = 110000.0;
-    static constexpr double kMaxCO2MoleFraction = 0.01;
+static constexpr double kMaxTemperature = 30.0;
+static constexpr double kMaxHumidity = 1.0;
+static constexpr double kMaxPressure = 102000.0;
+static constexpr double kMaxXwPressure = 110000.0;
+static constexpr double kMaxCO2MoleFraction = 0.01;
 
-    double T(double t);
-    double dT_dt();
+double T(double t);
+double dT_dt();
 
-    double F(double p, double t);
-    double dF_dp();
-    double dF_dt(double t);
+double F(double p, double t);
+double dF_dp();
+double dF_dt(double t);
 
-    double Psv(double T);
-    double dPsv_dt(double T);
+double Psv(double T);
+double dPsv_dt(double T);
 
-    double Xw(double h, double F, double Psv, double p);
-    double dXw_dh(double F, double Psv, double p);
-    double dXw_dF(double h, double Psv, double p);
-    double dXw_dPsv(double h, double F, double p);
-    double dXw_dp(double h, double F, double Psv, double p);
+double Xw(double h, double F, double Psv, double p);
+double dXw_dh(double F, double Psv, double p);
+double dXw_dF(double h, double Psv, double p);
+double dXw_dPsv(double h, double F, double p);
+double dXw_dp(double h, double F, double Psv, double p);
 
-    double C(double t, double p, double Xw, double xc);
-    double dC_dt(double t, double p, double Xw, double xc, double dXw_dF, double dF_dt, double dXw_dPsv, double dPsv_dt);
-    double dC_dXw(double t, double p, double Xw, double xc);
-    double dC_dxc(double t, double p, double Xw, double xc);
-    double dC_dp(double t, double p, double Xw, double xc, double dXw_dp);
-    double dC_dh(double dC_dXw, double dXw_dh);
+double C(double t, double p, double Xw, double xc);
+double dC_dt(double t, double p, double Xw, double xc, double dXw_dF,
+             double dF_dt, double dXw_dPsv, double dPsv_dt);
+double dC_dXw(double t, double p, double Xw, double xc);
+double dC_dxc(double t, double p, double Xw, double xc);
+double dC_dp(double t, double p, double Xw, double xc, double dXw_dp);
+double dC_dh(double dC_dXw, double dXw_dh);
 
-    static constexpr double k00 =  3.315024000e+02;
-    static constexpr double k01 =  6.030550000e-01;
-    static constexpr double k02 = -5.280000000e-04;
-    static constexpr double k03 =  5.147193500e+01;
-    static constexpr double k04 =  1.495874000e-01;
-    static constexpr double k05 = -7.820000000e-04;
-    static constexpr double k06 = -1.820000000e-07;
-    static constexpr double k07 =  3.730000000e-08;
-    static constexpr double k08 = -2.930000000e-10;
-    static constexpr double k09 = -8.520931000e+01;
-    static constexpr double k10 = -2.285250000e-01;
-    static constexpr double k11 =  5.910000000e-05;
-    static constexpr double k12 = -2.835149000e+00;
-    static constexpr double k13 = -2.150000000e-13;
-    static constexpr double k14 =  2.917976200e+01;
-    static constexpr double k15 =  4.860000000e-04;
-    static constexpr double k16 =  1.000620000e+00;
-    static constexpr double k17 =  3.140000000e-08;
-    static constexpr double k18 =  5.600000000e-07;
-    static constexpr double k19 =  1.281180500e-05;
-    static constexpr double k20 = -1.950987400e-02;
-    static constexpr double k21 =  3.404926034e+01;
-    static constexpr double k22 = -6.353631100e+03;
-  }
-}
+static constexpr double k00 = 3.315024000e+02;
+static constexpr double k01 = 6.030550000e-01;
+static constexpr double k02 = -5.280000000e-04;
+static constexpr double k03 = 5.147193500e+01;
+static constexpr double k04 = 1.495874000e-01;
+static constexpr double k05 = -7.820000000e-04;
+static constexpr double k06 = -1.820000000e-07;
+static constexpr double k07 = 3.730000000e-08;
+static constexpr double k08 = -2.930000000e-10;
+static constexpr double k09 = -8.520931000e+01;
+static constexpr double k10 = -2.285250000e-01;
+static constexpr double k11 = 5.910000000e-05;
+static constexpr double k12 = -2.835149000e+00;
+static constexpr double k13 = -2.150000000e-13;
+static constexpr double k14 = 2.917976200e+01;
+static constexpr double k15 = 4.860000000e-04;
+static constexpr double k16 = 1.000620000e+00;
+static constexpr double k17 = 3.140000000e-08;
+static constexpr double k18 = 5.600000000e-07;
+static constexpr double k19 = 1.281180500e-05;
+static constexpr double k20 = -1.950987400e-02;
+static constexpr double k21 = 3.404926034e+01;
+static constexpr double k22 = -6.353631100e+03;
+}  // namespace theory
+}  // namespace speedofsound
 
 #endif

--- a/test/speed_of_sound_test.cc
+++ b/test/speed_of_sound_test.cc
@@ -2,22 +2,12 @@
 #include "speed_of_sound_test.h"
 
 TEST_F(EnvironmentTest, EnvironmentConstructorDefaultValue) {
-  EXPECT_DOUBLE_EQ(
-    environment.temperature_,
-    speedofsound::theory::kStdTemperature
-  );
-  EXPECT_DOUBLE_EQ(
-    environment.humidity_,
-    speedofsound::theory::kStdHumidity
-  );
-  EXPECT_DOUBLE_EQ(
-    environment.pressure_,
-    speedofsound::theory::kStdPressure
-  );
-  EXPECT_DOUBLE_EQ(
-    environment.co2_mole_fraction_,
-    speedofsound::theory::kStdCO2MoleFraction
-  );
+  EXPECT_DOUBLE_EQ(environment.temperature_,
+                   speedofsound::theory::kStdTemperature);
+  EXPECT_DOUBLE_EQ(environment.humidity_, speedofsound::theory::kStdHumidity);
+  EXPECT_DOUBLE_EQ(environment.pressure_, speedofsound::theory::kStdPressure);
+  EXPECT_DOUBLE_EQ(environment.co2_mole_fraction_,
+                   speedofsound::theory::kStdCO2MoleFraction);
 }
 
 TEST_F(EnvironmentTest, EnvironmentValidateTemperature) {
@@ -75,14 +65,16 @@ TEST_F(EnvironmentTest, EnvironmentValidatePressure) {
 TEST_F(EnvironmentTest, EnvironmentValidateCO2MoleFraction) {
   double increment = 1e-3;
   EXPECT_TRUE(environment.ValidateCO2MoleFraction());
-  environment.co2_mole_fraction_ = speedofsound::theory::kMinCO2MoleFraction - increment;
+  environment.co2_mole_fraction_ =
+      speedofsound::theory::kMinCO2MoleFraction - increment;
   EXPECT_FALSE(environment.ValidateCO2MoleFraction());
   environment.co2_mole_fraction_ = speedofsound::theory::kMinCO2MoleFraction;
   EXPECT_TRUE(environment.ValidateCO2MoleFraction());
   environment.co2_mole_fraction_ += increment;
   EXPECT_TRUE(environment.ValidateCO2MoleFraction());
 
-  environment.co2_mole_fraction_ = speedofsound::theory::kMaxCO2MoleFraction - increment;
+  environment.co2_mole_fraction_ =
+      speedofsound::theory::kMaxCO2MoleFraction - increment;
   EXPECT_TRUE(environment.ValidateCO2MoleFraction());
   environment.co2_mole_fraction_ = speedofsound::theory::kMaxCO2MoleFraction;
   EXPECT_TRUE(environment.ValidateCO2MoleFraction());
@@ -105,33 +97,22 @@ TEST_F(EnvironmentTest, EnvironmentValidateEnvironment) {
   EXPECT_TRUE(environment.ValidateEnvironment());
 }
 
-
 TEST_F(EnvironmentRateTest, EnvironmentRateConstructorDefaultValue) {
   EXPECT_DOUBLE_EQ(environment_rate.temperature_rate_, 0.0);
   EXPECT_DOUBLE_EQ(environment_rate.humidity_rate_, 0.0);
   EXPECT_DOUBLE_EQ(environment_rate.pressure_rate_, 0.0);
   EXPECT_DOUBLE_EQ(environment_rate.co2_mole_fraction_rate_, 0.0);
-
 }
 
-
 TEST_F(SpeedOfSoundTest, EnvironmentConstructorDefaultValues) {
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().temperature_,
-    speedofsound::theory::kStdTemperature
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().humidity_,
-    speedofsound::theory::kStdHumidity
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().pressure_,
-    speedofsound::theory::kStdPressure
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().co2_mole_fraction_,
-    speedofsound::theory::kStdCO2MoleFraction
-  );
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().temperature_,
+                   speedofsound::theory::kStdTemperature);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().humidity_,
+                   speedofsound::theory::kStdHumidity);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().pressure_,
+                   speedofsound::theory::kStdPressure);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().co2_mole_fraction_,
+                   speedofsound::theory::kStdCO2MoleFraction);
 }
 
 TEST_F(SpeedOfSoundTest, EnvironmentOverloadConstructorValues) {
@@ -142,55 +123,51 @@ TEST_F(SpeedOfSoundTest, EnvironmentOverloadConstructorValues) {
   environment.co2_mole_fraction_ = speedofsound::theory::kMinCO2MoleFraction;
   speedofsound::SpeedOfSound speed_of_sound(environment);
 
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().temperature_,
-    speedofsound::theory::kMinTemperature
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().humidity_,
-    speedofsound::theory::kMinHumidity
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().pressure_,
-    speedofsound::theory::kMinPressure
-  );
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.GetInitEnvironment().co2_mole_fraction_,
-    speedofsound::theory::kMinCO2MoleFraction
-  );
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().temperature_,
+                   speedofsound::theory::kMinTemperature);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().humidity_,
+                   speedofsound::theory::kMinHumidity);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().pressure_,
+                   speedofsound::theory::kMinPressure);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironment().co2_mole_fraction_,
+                   speedofsound::theory::kMinCO2MoleFraction);
 }
 
 TEST_F(SpeedOfSoundTest, EnvironmentRateConstructorDefaultValues) {
   double t, h, p, xc, T, F, Psv, Xw, dF_dt, dPsv_dt, dXw_dh, dXw_dF, dXw_dPsv,
-    dXw_dp, dC_dt, dC_dh, dC_dp, dC_dXw, dC_dxc;
+      dXw_dp, dC_dt, dC_dh, dC_dp, dC_dXw, dC_dxc;
 
-  t  = speedofsound::theory::kStdTemperature;
-  h  = speedofsound::theory::kStdHumidity;
-  p  = speedofsound::theory::kStdPressure;
+  t = speedofsound::theory::kStdTemperature;
+  h = speedofsound::theory::kStdHumidity;
+  p = speedofsound::theory::kStdPressure;
   xc = speedofsound::theory::kStdCO2MoleFraction;
 
-  T        = speedofsound::theory::T(t);
-  F        = speedofsound::theory::F(p, t);
-  Psv      = speedofsound::theory::Psv(T);
-  Xw       = speedofsound::theory::Xw(h, F, Psv, p);
-  dF_dt    = speedofsound::theory::dF_dt(t);
-  dPsv_dt  = speedofsound::theory::dPsv_dt(T);
-  dXw_dh   = speedofsound::theory::dXw_dh(F, Psv, p);
-  dXw_dF   = speedofsound::theory::dXw_dF(h, Psv, p);
+  T = speedofsound::theory::T(t);
+  F = speedofsound::theory::F(p, t);
+  Psv = speedofsound::theory::Psv(T);
+  Xw = speedofsound::theory::Xw(h, F, Psv, p);
+  dF_dt = speedofsound::theory::dF_dt(t);
+  dPsv_dt = speedofsound::theory::dPsv_dt(T);
+  dXw_dh = speedofsound::theory::dXw_dh(F, Psv, p);
+  dXw_dF = speedofsound::theory::dXw_dF(h, Psv, p);
   dXw_dPsv = speedofsound::theory::dXw_dPsv(h, F, p);
-  dXw_dp   = speedofsound::theory::dXw_dp(h, F, Psv, p);
-  dC_dt    = speedofsound::theory::dC_dt(t, p, Xw, xc, dXw_dF, dF_dt, dXw_dPsv, dPsv_dt);
-  dC_dxc   = speedofsound::theory::dC_dxc(t, p, Xw, xc);
-  dC_dp    = speedofsound::theory::dC_dp(t, p, Xw, xc, dXw_dp);
-  dC_dXw   = speedofsound::theory::dC_dXw(t, p, Xw, xc);
-  dC_dh    = speedofsound::theory::dC_dh(dC_dXw, dXw_dh);
+  dXw_dp = speedofsound::theory::dXw_dp(h, F, Psv, p);
+  dC_dt = speedofsound::theory::dC_dt(t, p, Xw, xc, dXw_dF, dF_dt, dXw_dPsv,
+                                      dPsv_dt);
+  dC_dxc = speedofsound::theory::dC_dxc(t, p, Xw, xc);
+  dC_dp = speedofsound::theory::dC_dp(t, p, Xw, xc, dXw_dp);
+  dC_dXw = speedofsound::theory::dC_dXw(t, p, Xw, xc);
+  dC_dh = speedofsound::theory::dC_dh(dC_dXw, dXw_dh);
 
-  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().temperature_rate_, dC_dt);
-  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().humidity_rate_, dC_dh);
-  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().pressure_rate_, dC_dp);
-  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().co2_mole_fraction_rate_, dC_dxc);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().temperature_rate_,
+                   dC_dt);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().humidity_rate_,
+                   dC_dh);
+  EXPECT_DOUBLE_EQ(speed_of_sound.GetInitEnvironmentRate().pressure_rate_,
+                   dC_dp);
+  EXPECT_DOUBLE_EQ(
+      speed_of_sound.GetInitEnvironmentRate().co2_mole_fraction_rate_, dC_dxc);
 }
-
 
 TEST_F(SpeedOfSoundTest, ComputeReturnsCorrectValue) {
   double t, h, p, xc, c, T, F, Psv, Xw, C;
@@ -199,18 +176,19 @@ TEST_F(SpeedOfSoundTest, ComputeReturnsCorrectValue) {
   for (t = kTMin; t <= kTMax; t += (kTMax - kTMin) * kIncrementFactor) {
     for (h = kHMin; h <= kHMax; h += (kHMax - kHMin) * kIncrementFactor) {
       for (p = kPMin; p <= kPMax; p += (kPMax - kPMin) * kIncrementFactor) {
-        for (xc = kXcMin; xc <= kXcMax; xc += (kXcMax - kXcMin) * kIncrementFactor) {
+        for (xc = kXcMin; xc <= kXcMax;
+             xc += (kXcMax - kXcMin) * kIncrementFactor) {
           environment.temperature_ = t;
           environment.humidity_ = h;
           environment.pressure_ = p;
           environment.co2_mole_fraction_ = xc;
           c = speed_of_sound.Compute(environment);
 
-          T   = speedofsound::theory::T(t);
-          F   = speedofsound::theory::F(p, t);
+          T = speedofsound::theory::T(t);
+          F = speedofsound::theory::F(p, t);
           Psv = speedofsound::theory::Psv(T);
-          Xw  = speedofsound::theory::Xw(h, F, Psv, p);
-          C   = speedofsound::theory::C(t, p, Xw, xc);
+          Xw = speedofsound::theory::Xw(h, F, Psv, p);
+          C = speedofsound::theory::C(t, p, Xw, xc);
 
           ASSERT_DOUBLE_EQ(C, c);
         }
@@ -226,12 +204,13 @@ TEST_F(SpeedOfSoundTest, QuickComputeReturnsCorrectValue) {
   for (t = kTMin; t <= kTMax; t += (kTMax - kTMin) * kIncrementFactor) {
     for (h = kHMin; h <= kHMax; h += (kHMax - kHMin) * kIncrementFactor) {
       for (p = kPMin; p <= kPMax; p += (kPMax - kPMin) * kIncrementFactor) {
-        for (xc = kXcMin; xc <= kXcMax; xc += (kXcMax - kXcMin) * kIncrementFactor) {
-          T   = speedofsound::theory::T(t);
-          F   = speedofsound::theory::F(p, t);
+        for (xc = kXcMin; xc <= kXcMax;
+             xc += (kXcMax - kXcMin) * kIncrementFactor) {
+          T = speedofsound::theory::T(t);
+          F = speedofsound::theory::F(p, t);
           Psv = speedofsound::theory::Psv(T);
-          Xw  = speedofsound::theory::Xw(h, F, Psv, p);
-          C   = speedofsound::theory::C(t, p, Xw, xc);
+          Xw = speedofsound::theory::Xw(h, F, Psv, p);
+          C = speedofsound::theory::C(t, p, Xw, xc);
 
           environment.temperature_ = t;
           environment.humidity_ = h;
@@ -248,28 +227,22 @@ TEST_F(SpeedOfSoundTest, QuickComputeReturnsCorrectValue) {
 
 TEST_F(SpeedOfSoundTest, ApproximationReturnsCorrectValue) {
   speedofsound::Environment environment, environment_higher, environment_lower;
-  EXPECT_DOUBLE_EQ(
-    speed_of_sound.Compute(environment),
-    speed_of_sound.Approximate(environment)
-  );
+  EXPECT_DOUBLE_EQ(speed_of_sound.Compute(environment),
+                   speed_of_sound.Approximate(environment));
 
   environment_higher.temperature_ += 5.0;
   environment_higher.humidity_ += 0.2;
   environment_higher.pressure_ += 600;
   environment_higher.co2_mole_fraction_ += 0.003;
-  EXPECT_DOUBLE_EQ(
-    347.0974896038062,
-    speed_of_sound.Approximate(environment_higher)
-  );
+  EXPECT_DOUBLE_EQ(347.0974896038062,
+                   speed_of_sound.Approximate(environment_higher));
 
   environment_lower.temperature_ -= 12.0;
   environment_lower.humidity_ -= 0.3;
   environment_lower.pressure_ -= 2000;
   environment_lower.co2_mole_fraction_ -= 0.0001;
-  EXPECT_DOUBLE_EQ(
-    336.14277346708593,
-    speed_of_sound.Approximate(environment_lower)
-  );
+  EXPECT_DOUBLE_EQ(336.14277346708593,
+                   speed_of_sound.Approximate(environment_lower));
 }
 
 TEST_F(SpeedOfSoundTest, LinearApproximationResultWithinTolerance) {
@@ -281,7 +254,8 @@ TEST_F(SpeedOfSoundTest, LinearApproximationResultWithinTolerance) {
   for (t = kTMin; t <= kTMax; t += (kTMax - kTMin) * kIncrementFactor) {
     for (h = kHMin; h <= kHMax; h += (kHMax - kHMin) * kIncrementFactor) {
       for (p = kPMin; p <= kPMax; p += (kPMax - kPMin) * kIncrementFactor) {
-        for (xc = kXcMin; xc <= kXcMax; xc += (kXcMax - kXcMin) * kIncrementFactor) {
+        for (xc = kXcMin; xc <= kXcMax;
+             xc += (kXcMax - kXcMin) * kIncrementFactor) {
           e_init.temperature_ = t;
           e_init.humidity_ = h;
           e_init.pressure_ = p;
@@ -321,7 +295,8 @@ TEST_F(SpeedOfSoundTest, ApproximationFasterThanQuickCompute) {
     for (t = kTMin; t <= kTMax; t += (kTMax - kTMin) * kIncrementFactor) {
       for (h = kHMin; h <= kHMax; h += (kHMax - kHMin) * kIncrementFactor) {
         for (p = kPMin; p <= kPMax; p += (kPMax - kPMin) * kIncrementFactor) {
-          for (xc = kXcMin; xc <= kXcMax; xc += (kXcMax - kXcMin) * kIncrementFactor) {
+          for (xc = kXcMin; xc <= kXcMax;
+               xc += (kXcMax - kXcMin) * kIncrementFactor) {
             environment.temperature_ = t;
             environment.humidity_ = h;
             environment.pressure_ = p;
@@ -338,7 +313,8 @@ TEST_F(SpeedOfSoundTest, ApproximationFasterThanQuickCompute) {
     for (t = kTMin; t <= kTMax; t += (kTMax - kTMin) * kIncrementFactor) {
       for (h = kHMin; h <= kHMax; h += (kHMax - kHMin) * kIncrementFactor) {
         for (p = kPMin; p <= kPMax; p += (kPMax - kPMin) * kIncrementFactor) {
-          for (xc = kXcMin; xc <= kXcMax; xc += (kXcMax - kXcMin) * kIncrementFactor) {
+          for (xc = kXcMin; xc <= kXcMax;
+               xc += (kXcMax - kXcMin) * kIncrementFactor) {
             environment.temperature_ = t;
             environment.humidity_ = h;
             environment.pressure_ = p;
@@ -351,8 +327,11 @@ TEST_F(SpeedOfSoundTest, ApproximationFasterThanQuickCompute) {
     auto approximation_timer_end = std::chrono::high_resolution_clock::now();
     approximation_time = approximation_timer_end - approximation_timer_start;
 
-    if (approximation_time.count() <= quick_compute_time.count() * runtime_ratio) break;
+    if (approximation_time.count() <=
+        quick_compute_time.count() * runtime_ratio)
+      break;
   }
 
-  EXPECT_LE(approximation_time.count(), quick_compute_time.count() * runtime_ratio);
+  EXPECT_LE(approximation_time.count(),
+            quick_compute_time.count() * runtime_ratio);
 }

--- a/test/speed_of_sound_test.h
+++ b/test/speed_of_sound_test.h
@@ -5,28 +5,28 @@
 #define TEST_SPEED_OF_SOUND_TEST_H_
 
 class EnvironmentTest : public ::testing::Test {
-  public:
-    speedofsound::Environment environment;
+ public:
+  speedofsound::Environment environment;
 };
 
 class EnvironmentRateTest : public ::testing::Test {
-  public:
-    speedofsound::EnvironmentRate environment_rate;
+ public:
+  speedofsound::EnvironmentRate environment_rate;
 };
 
 class SpeedOfSoundTest : public ::testing::Test {
-  public:
-    speedofsound::SpeedOfSound speed_of_sound;
+ public:
+  speedofsound::SpeedOfSound speed_of_sound;
 
-    static constexpr double kIncrementFactor = 2.0 / 100.0;
-    static constexpr double kTMin  = speedofsound::theory::kMinTemperature;
-    static constexpr double kTMax  = speedofsound::theory::kMaxTemperature;
-    static constexpr double kHMin  = speedofsound::theory::kMinHumidity;
-    static constexpr double kHMax  = speedofsound::theory::kMaxHumidity;
-    static constexpr double kPMin  = speedofsound::theory::kMinPressure;
-    static constexpr double kPMax  = speedofsound::theory::kMaxPressure;
-    static constexpr double kXcMin = speedofsound::theory::kMinCO2MoleFraction;
-    static constexpr double kXcMax = speedofsound::theory::kMaxCO2MoleFraction;
+  static constexpr double kIncrementFactor = 2.0 / 100.0;
+  static constexpr double kTMin = speedofsound::theory::kMinTemperature;
+  static constexpr double kTMax = speedofsound::theory::kMaxTemperature;
+  static constexpr double kHMin = speedofsound::theory::kMinHumidity;
+  static constexpr double kHMax = speedofsound::theory::kMaxHumidity;
+  static constexpr double kPMin = speedofsound::theory::kMinPressure;
+  static constexpr double kPMax = speedofsound::theory::kMaxPressure;
+  static constexpr double kXcMin = speedofsound::theory::kMinCO2MoleFraction;
+  static constexpr double kXcMax = speedofsound::theory::kMaxCO2MoleFraction;
 };
 
 #endif

--- a/test/speed_of_sound_theory_test.cc
+++ b/test/speed_of_sound_theory_test.cc
@@ -23,18 +23,15 @@ SpeedOfSoundTheoryTest::SpeedOfSoundTheoryTest() {
   max_xw_case.co2_mole_fraction_ = speedofsound::theory::kMaxCO2MoleFraction;
 }
 
-
 TEST_F(SpeedOfSoundTheoryTest, T) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 18.284148638241625;
-  test_cases = {
-    {273.15, min_case},
-    {291.4341486382416, random_case},
-    {293.15, std_case},
-    {303.15, max_case}
-  };
+  test_cases = {{273.15, min_case},
+                {291.4341486382416, random_case},
+                {293.15, std_case},
+                {303.15, max_case}};
   double t, T;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     T = speedofsound::theory::T(t);
     EXPECT_DOUBLE_EQ(test_case.first, T);
@@ -45,22 +42,19 @@ TEST_F(SpeedOfSoundTheoryTest, dT_dt) {
   EXPECT_DOUBLE_EQ(1.0, speedofsound::theory::dT_dt());
 }
 
-
 TEST_F(SpeedOfSoundTheoryTest, F) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 27.844468454693093;
   random_case.pressure_ = 89656.35925586602;
-  test_cases = {
-    {1.002504, min_xw_case},
-    {1.0038693857578078, random_case},
-    {1.004025605, std_case},
-    {1.0045780000000002, max_xw_case}
-  };
+  test_cases = {{1.002504, min_xw_case},
+                {1.0038693857578078, random_case},
+                {1.004025605, std_case},
+                {1.0045780000000002, max_xw_case}};
   double p, t, F;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     p = test_case.second.pressure_;
     t = test_case.second.temperature_;
-    F =  speedofsound::theory::F(p, t);
+    F = speedofsound::theory::F(p, t);
     EXPECT_DOUBLE_EQ(test_case.first, F);
   }
 }
@@ -72,32 +66,27 @@ TEST_F(SpeedOfSoundTheoryTest, dF_dp) {
 TEST_F(SpeedOfSoundTheoryTest, dF_dt) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 12.294236473063911;
-  test_cases = {
-    {0.0,  min_xw_case},
-    {0.00001376954484983158, random_case},
-    {0.000022399999999999996, std_case},
-    {0.0000336, max_xw_case}
-  };
+  test_cases = {{0.0, min_xw_case},
+                {0.00001376954484983158, random_case},
+                {0.000022399999999999996, std_case},
+                {0.0000336, max_xw_case}};
   double t, dF_dt;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     dF_dt = speedofsound::theory::dF_dt(t);
     EXPECT_DOUBLE_EQ(test_case.first, dF_dt);
   }
 }
 
-
 TEST_F(SpeedOfSoundTheoryTest, Psv) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 2.1984818036360068;
-  test_cases = {
-    {611.2129344513172, min_xw_case},
-    {716.0310817057355, random_case},
-    {2338.5721154062803, std_case},
-    {4245.190531747869, max_xw_case}
-  };
+  test_cases = {{611.2129344513172, min_xw_case},
+                {716.0310817057355, random_case},
+                {2338.5721154062803, std_case},
+                {4245.190531747869, max_xw_case}};
   double T, Psv;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     T = speedofsound::theory::T(test_case.second.temperature_);
     Psv = speedofsound::theory::Psv(T);
     EXPECT_NEAR(test_case.first, Psv, test_case.first * kTolerance);
@@ -107,34 +96,29 @@ TEST_F(SpeedOfSoundTheoryTest, Psv) {
 TEST_F(SpeedOfSoundTheoryTest, dPsv_dt) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 8.105720408347487;
-  test_cases = {
-    {44.40221431628648, min_xw_case},
-    {73.4960648857937, random_case},
-    {144.84027310567882, std_case},
-    {243.64989811537197, max_xw_case}
-  };
+  test_cases = {{44.40221431628648, min_xw_case},
+                {73.4960648857937, random_case},
+                {144.84027310567882, std_case},
+                {243.64989811537197, max_xw_case}};
   double T, dPsv_dt;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     T = speedofsound::theory::T(test_case.second.temperature_);
     dPsv_dt = speedofsound::theory::dPsv_dt(T);
     EXPECT_NEAR(test_case.first, dPsv_dt, test_case.first * kTolerance);
   }
 }
 
-
 TEST_F(SpeedOfSoundTheoryTest, Xw) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 11.998297271608877;
   random_case.humidity_ = 0.34202164822956593;
   random_case.pressure_ = 67874.61330893353;
-  test_cases = {
-    {0.0, min_xw_case},
-    {0.007086640331164677, random_case},
-    {0.011586411463147895, std_case},
-    {0.03876931830911101, max_xw_case}
-  };
+  test_cases = {{0.0, min_xw_case},
+                {0.007086640331164677, random_case},
+                {0.011586411463147895, std_case},
+                {0.03876931830911101, max_xw_case}};
   double t, h, p, F, Psv, Xw;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -149,14 +133,12 @@ TEST_F(SpeedOfSoundTheoryTest, dXw_dh) {
   speedofsound::Environment random_case;
   random_case.temperature_ = 23.807213428100113;
   random_case.pressure_ = 90725.80279070066;
-  test_cases = {
-    {0.01021239019398639, min_xw_case},
-    {0.03264236679363074, random_case},
-    {0.02317282292629579, std_case},
-    {0.03876931830911101, max_xw_case}
-  };
+  test_cases = {{0.01021239019398639, min_xw_case},
+                {0.03264236679363074, random_case},
+                {0.02317282292629579, std_case},
+                {0.03876931830911101, max_xw_case}};
   double t, p, F, Psv, dXw_dh;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     p = test_case.second.pressure_;
     F = speedofsound::theory::F(p, t);
@@ -171,14 +153,12 @@ TEST_F(SpeedOfSoundTheoryTest, dXw_dF) {
   random_case.temperature_ = 12.347891354488652;
   random_case.humidity_ = 0.1629359256607068;
   random_case.pressure_ = 90930.00940507354;
-  test_cases = {
-    {0.0, min_xw_case},
-    {0.002571419561273468, random_case},
-    {0.011539956157938715, std_case},
-    {0.038592641197707896, max_xw_case}
-  };
+  test_cases = {{0.0, min_xw_case},
+                {0.002571419561273468, random_case},
+                {0.011539956157938715, std_case},
+                {0.038592641197707896, max_xw_case}};
   double t, h, p, Psv, dXw_dF;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -192,14 +172,12 @@ TEST_F(SpeedOfSoundTheoryTest, dXw_dPsv) {
   random_case.temperature_ = 4.848721185763054;
   random_case.humidity_ = 0.8556806268369959;
   random_case.pressure_ = 62674.21872949686;
-  test_cases = {
-    {0.0, min_xw_case},
-    {0.000013688345639018303, random_case},
-    {4.954481149765606e-6, std_case},
-    {9.132527272727275e-6, max_xw_case}
-  };
+  test_cases = {{0.0, min_xw_case},
+                {0.000013688345639018303, random_case},
+                {4.954481149765606e-6, std_case},
+                {9.132527272727275e-6, max_xw_case}};
   double t, h, p, F, dXw_dPsv;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -214,14 +192,12 @@ TEST_F(SpeedOfSoundTheoryTest, dXw_dp) {
   random_case.temperature_ = 2.8967257386015532;
   random_case.humidity_ = 0.5169528442922398;
   random_case.pressure_ = 106192.0489382949;
-  test_cases = {
-    {0.0, min_xw_case},
-    {-3.451789197083466e-8, random_case},
-    {-1.1398663588389851e-7, std_case},
-    {-3.512365393310375e-7, max_xw_case}
-  };
+  test_cases = {{0.0, min_xw_case},
+                {-3.451789197083466e-8, random_case},
+                {-1.1398663588389851e-7, std_case},
+                {-3.512365393310375e-7, max_xw_case}};
   double t, h, p, F, Psv, dXw_dp;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -231,7 +207,6 @@ TEST_F(SpeedOfSoundTheoryTest, dXw_dp) {
     EXPECT_NEAR(test_case.first, dXw_dp, -1.0 * test_case.first * kTolerance);
   }
 }
-
 
 TEST_F(SpeedOfSoundTheoryTest, C) {
   speedofsound::Environment random_case_1, random_case_2;
@@ -243,15 +218,13 @@ TEST_F(SpeedOfSoundTheoryTest, C) {
   random_case_2.humidity_ = 0.0326086454966481;
   random_case_2.pressure_ = 96000.82892784919;
   random_case_2.co2_mole_fraction_ = 0.0030235205198150903;
-  test_cases = {
-    {331.48754062500007, min_case},
-    {334.08459414185165, random_case_1},
-    {337.9787163164935, random_case_2},
-    {343.9943970603679, std_case},
-    {350.593524548772, max_case}
-  };
+  test_cases = {{331.48754062500007, min_case},
+                {334.08459414185165, random_case_1},
+                {337.9787163164935, random_case_2},
+                {343.9943970603679, std_case},
+                {350.593524548772, max_case}};
   double t, h, p, xc, F, Psv, Xw, C;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -270,14 +243,12 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dt) {
   random_case.humidity_ = 0.04306573258518309;
   random_case.pressure_ = 100339.02623320109;
   random_case.co2_mole_fraction_ = 0.001142713269765925;
-  test_cases = {
-    {0.6058525, min_case},
-    {0.5990025466394929, random_case},
-    {0.6246637009346002, std_case},
-    {0.7086882617549803, max_case}
-  };
+  test_cases = {{0.6058525, min_case},
+                {0.5990025466394929, random_case},
+                {0.6246637009346002, std_case},
+                {0.7086882617549803, max_case}};
   double t, h, p, xc, F, Psv, Xw, dXw_dF, dF_dt, dXw_dPsv, dPsv_dt, dC_dt;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -290,7 +261,7 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dt) {
     dXw_dPsv = speedofsound::theory::dXw_dPsv(h, F, p);
     dPsv_dt = speedofsound::theory::dPsv_dt(speedofsound::theory::T(t));
     dC_dt = speedofsound::theory::dC_dt(t, p, Xw, xc, dXw_dF, dF_dt, dXw_dPsv,
-      dPsv_dt);
+                                        dPsv_dt);
     EXPECT_NEAR(test_case.first, dC_dt, test_case.first * kTolerance);
   }
 }
@@ -301,14 +272,12 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dXw) {
   random_case.humidity_ = 0.3356317205048449;
   random_case.pressure_ = 91021.06631986011;
   random_case.co2_mole_fraction_ = 0.001022633303459329;
-  test_cases = {
-    {51.471935, min_case},
-    {54.83927112325779, random_case},
-    {54.10064719455334, std_case},
-    {55.514460843843075, max_case}
-  };
+  test_cases = {{51.471935, min_case},
+                {54.83927112325779, random_case},
+                {54.10064719455334, std_case},
+                {55.514460843843075, max_case}};
   double t, h, p, xc, F, Psv, Xw, dC_dXw;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -327,14 +296,12 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dxc) {
   random_case.humidity_ = 0.45418417642349995;
   random_case.pressure_ = 76777.7224873716;
   random_case.co2_mole_fraction_ = 0.0019591670521459936;
-  test_cases = {
-    {-85.20931, min_case},
-    {-89.45230237346945, random_case},
-    {-89.16728444269332, std_case},
-    {-89.35618526963965, max_case}
-  };
+  test_cases = {{-85.20931, min_case},
+                {-89.45230237346945, random_case},
+                {-89.16728444269332, std_case},
+                {-89.35618526963965, max_case}};
   double t, h, p, xc, F, Psv, Xw, dC_dxc;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -353,14 +320,12 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dp) {
   random_case.humidity_ = 0.8929583480896977;
   random_case.pressure_ = 78994.74831236238;
   random_case.co2_mole_fraction_ = 0.003932372141783944;
-  test_cases = {
-    {-2.1425e-7, min_case},
-    {-0.00002145591319831367, random_case},
-    {-5.761752390113884e-6, std_case},
-    {-0.00002184468771493967, max_case}
-  };
+  test_cases = {{-2.1425e-7, min_case},
+                {-0.00002145591319831367, random_case},
+                {-5.761752390113884e-6, std_case},
+                {-0.00002184468771493967, max_case}};
   double t, h, p, xc, F, Psv, Xw, dXw_dp, dC_dp;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;
@@ -380,14 +345,12 @@ TEST_F(SpeedOfSoundTheoryTest, dC_dh) {
   random_case.humidity_ = 0.0928206714768458;
   random_case.pressure_ = 99919.41775510696;
   random_case.co2_mole_fraction_ = 0.0013816954173898905;
-  test_cases = {
-    {0.42071875816968457, min_case},
-    {1.5422750283964233, random_case},
-    {1.2536647176373856, std_case},
-    {2.3204819429829007, max_case}
-  };
+  test_cases = {{0.42071875816968457, min_case},
+                {1.5422750283964233, random_case},
+                {1.2536647176373856, std_case},
+                {2.3204819429829007, max_case}};
   double t, h, p, xc, F, Psv, Xw, dC_dXw, dXw_dh, dC_dh;
-  for (auto test_case: test_cases) {
+  for (auto test_case : test_cases) {
     t = test_case.second.temperature_;
     h = test_case.second.humidity_;
     p = test_case.second.pressure_;

--- a/test/speed_of_sound_theory_test.h
+++ b/test/speed_of_sound_theory_test.h
@@ -1,20 +1,20 @@
 // speed_of_sound_theory_test.h
-#include <vector>
 #include <tuple>
+#include <vector>
 #include "test.h"
 
 #ifndef TEST_SPEED_OF_SOUND_THEORY_TEST_H_
 #define TEST_SPEED_OF_SOUND_THEORY_TEST_H_
 
 class SpeedOfSoundTheoryTest : public ::testing::Test {
-  public:
-    SpeedOfSoundTheoryTest();
+ public:
+  SpeedOfSoundTheoryTest();
 
-    speedofsound::Environment min_case, min_xw_case, std_case,
-      max_case, max_xw_case;
+  speedofsound::Environment min_case, min_xw_case, std_case, max_case,
+      max_xw_case;
 
-    std::vector< std::pair<double, speedofsound::Environment> > test_cases;
-    static constexpr double kTolerance = 1.0e-14;
+  std::vector<std::pair<double, speedofsound::Environment> > test_cases;
+  static constexpr double kTolerance = 1.0e-14;
 };
 
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -1,5 +1,5 @@
 // test.h
+#include <chrono>
 #include "gtest/gtest.h"
 #include "speed_of_sound.h"
 #include "speed_of_sound_theory.h"
-#include <chrono>


### PR DESCRIPTION
Run `clang-tidy` against all code to ensure it conforms with the style guide (Google).