### PR TITLE
Gardening: check-code-style logic

### DIFF
--- a/check-code-style
+++ b/check-code-style
@@ -3,11 +3,11 @@ import subprocess
 
 output = subprocess.check_output(['git', 'clang-format-5.0', 
     '--binary', 'clang-format-5.0', '--commit', 'HEAD~1', '--diff'])
-if output.strip().lower() not in [b'no modified files to format',
-                                  b'clang-format did not modify any files']:
+if output.strip().lower() in [b'no modified files to format',
+                              b'clang-format did not modify any files']:
+    print(output.strip().decode('utf-8'))
+    exit(0)
+else:
     print('Code style does not match clang-format')
     print(output.strip().decode('utf-8'))
     exit(1)
-else:
-    print(output.strip().decode('utf-8'))
-    exit(0)


### PR DESCRIPTION
Small modification to `check-code-style`'s logic so `if` condition does not contain a negation.