### PR TITLE
Build against multiple compilers in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,30 +2,51 @@ version: 2
 jobs:
   check-code-style:
     docker:
-      - image: lelandjansen/speed-of-sound-toolchain:0.0.2
+      - image: lelandjansen/speed-of-sound-toolchain:1.0.0
     steps:
       - checkout
       - run:
           name: Check code style
           command: ./check-code-style
-  build-release:
+  build-release-clang:
     docker:
-      - image: lelandjansen/speed-of-sound-toolchain:0.0.2
+      - image: lelandjansen/speed-of-sound-toolchain:1.0.0
     steps:
       - checkout
-      - run: 
-          name: Git submodules
-          command: git submodule update --init --recursive
+      - run: git submodule update --init --recursive
       - run:
-          name: Build (release)
+          name: Build with clang (release)
           command: |
-            cmake \
-              -DCMAKE_BUILD_TYPE=RELEASE \
-              .
+            CC=clang-5.0 CXX=clang++-5.0 \
+              cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTS=TRUE
             cmake --build . -- -j2
-  build-debug-and-test:
+  build-release-gcc:
     docker:
-      - image: lelandjansen/speed-of-sound-toolchain:0.0.2
+      - image: lelandjansen/speed-of-sound-toolchain:1.0.0
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - run:
+          name: Build with gcc (release)
+          command: |
+            CC=gcc CXX=g++ \
+              cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTS=TRUE
+            cmake --build . -- -j2
+  build-release-avr-gcc:
+    docker:
+      - image: lelandjansen/speed-of-sound-toolchain:1.0.0
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - run:
+          name: Build with avr-gcc (release)
+          command: |
+            CC=avr-gcc CXX=avr-g++ \
+              cmake . -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTS=FALSE
+            cmake --build . -- -j2
+  build-debug-test-coverage:
+    docker:
+      - image: lelandjansen/speed-of-sound-toolchain:1.0.0
     environment:
       COVERALLS_REPO_TOKEN: Ny1fDedTzf5EuoygukebX5x28beAqhHD9
     steps:
@@ -36,15 +57,13 @@ jobs:
       - run: 
           name: Build (debug)
           command: |
-            cmake \
-              -DCMAKE_BUILD_TYPE=DEBUG \
-              .
+            cmake . -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_TESTS=TRUE
             cmake --build . -- -j2
       - run:
           name: Run unit tests
           command: ./unit_tests
       - run:
-          name: Coveralls
+          name: Test coverage with Coveralls
           when: on_success
           command: coveralls --include src
 workflows:
@@ -52,6 +71,7 @@ workflows:
   build_and_test:
     jobs:
       - check-code-style
-      - build-release
-      - build-debug-and-test
- 
+      - build-release-clang
+      - build-release-gcc
+      - build-release-avr-gcc
+      - build-debug-test-coverage

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
-Checks: '*,android*,-boost*'
+Checks: '*,-android*,-boost*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '*'
 CheckOptions:
   - key: readability-braces-around-statements.ShortStatementLines
     value: 1
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
 project(speed-of-sound)
 
@@ -12,7 +12,9 @@ find_program(clang_tidy_executable NAMES
   clang-tidy
   clang-tidy-5.0)
 set(clang_tidy_line_filters "[{'name': 'external/*'}]")
-set(base_clang_tidy "${clang_tidy_executable};-line-filter=${clang_tidy_line_filters}")
+set(base_clang_tidy
+  "${clang_tidy_executable};-line-filter=${clang_tidy_line_filters}")
+
 if(CMAKE_BUILD_TYPE MATCHES DEBUG)
   message("DEBUG mode")
   set(build_type_flags "-g -Og --coverage -fno-exceptions")
@@ -23,8 +25,9 @@ else()
   set(CMAKE_CXX_CLANG_TIDY "${base_clang_tidy};-warnings-as-errors=*")
 endif()
 
+
 set(CMAKE_CXX_FLAGS
-  "${build_type_flags}")
+  "${CMAKE_CXX_FLAGS} ${build_type_flags}")
 include_directories(
   ${PROJECT_SOURCE_DIR}/src)
 add_library(
@@ -33,30 +36,30 @@ add_library(
   src/speed-of-sound.cc
   src/speed-of-sound-theory.cc)
 
-# Unit tests
-set(GOOGLETEST_ROOT external/googletest/googletest)
-include_directories(
-  ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
-  ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include)
-set(GOOGLETEST_SOURCES
-  ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
-  ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest_main.cc)
-foreach(_source ${GOOGLETEST_SOURCES})
-  set_source_files_properties(${_source} PROPERTIES GENERATED 1)
-endforeach()
-add_library(googletest ${GOOGLETEST_SOURCES})
-add_executable(
-  unit_tests
-  test/test.cc
-  test/speed-of-sound_test.cc
-  test/speed-of-sound-theory_test.cc)
-add_dependencies(unit_tests googletest)
-target_link_libraries(
-  unit_tests
-  googletest
-  speed_of_sound
-  pthread)
+if(BUILD_TESTS)
+  set(googletest_root external/googletest/googletest)
+  include_directories(
+    ${PROJECT_SOURCE_DIR}/${googletest_root}
+    ${PROJECT_SOURCE_DIR}/${googletest_root}/include)
+  set(googletest_sources
+    ${PROJECT_SOURCE_DIR}/${googletest_root}/src/gtest-all.cc
+    ${PROJECT_SOURCE_DIR}/${googletest_root}/src/gtest_main.cc)
+  foreach(_source ${googletest_sources})
+    set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+  endforeach()
+  add_library(googletest ${googletest_sources})
+  add_executable(unit_tests
+    test/test.cc
+    test/speed-of-sound_test.cc
+    test/speed-of-sound-theory_test.cc)
+  add_dependencies(unit_tests googletest)
+  target_link_libraries(
+    unit_tests
+    googletest
+    speed_of_sound
+    pthread)
 
-include(CTest)
-enable_testing()
-add_test(unit ${PROJECT_BINARY_DIR}/unit_tests)
+  include(CTest)
+  enable_testing()
+  add_test(unit ${PROJECT_BINARY_DIR}/unit_tests)
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get install -y \
   ca-certificates
 
 # Our general requirements
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
+  wget \
+  bzip2 \
   build-essential \
   software-properties-common
 
@@ -36,8 +38,12 @@ RUN cd cmake-3.9.4 && \
 RUN rm cmake-3.9.4.tar.gz && \
   rm -rf cmake-3.9.4
 
+# GNU AVR Embedded Toolchain
+RUN apt-get install -y \
+  gcc-avr \
+  avr-libc
+
 # Coveralls
 RUN apt-get install -y python-pip
 RUN pip install --upgrade pip
 RUN pip install --prefix /usr/local cpp-coveralls
-

--- a/src/speed-of-sound-theory.cc
+++ b/src/speed-of-sound-theory.cc
@@ -1,6 +1,8 @@
 #include "speed-of-sound-theory.h"
 
-#include <cmath>
+// Using math.h instead of cmath because cmath is often not available on
+// embedded compilers
+#include <math.h>
 
 namespace speedofsound {
 

--- a/test/test
+++ b/test/test
@@ -2,7 +2,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$DIR/../build"
 mkdir -p "$BUILD_DIR/build"
-cmake -B$BUILD_DIR -H$DIR/..
-make -j2 -C $BUILD_DIR
+cmake -B$BUILD_DIR -H$DIR/.. -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTS=TRUE
+cmake --build $BUILD_DIR -- -j2
 $BUILD_DIR/unit_tests
-


### PR DESCRIPTION
Resolves #9.
* Builds the library against `gcc`, `clang`, and `avr-gcc`
  * Not compiling against `arm-none-eabi-gcc` because it requires us to remove CMake's compiler check.
* Added a `BUILD_TESTS` flag that must be set in order to build the unit tests. This is required because we can't compile/run GoogleTest on embedded platforms.
* Updated CMake version from 3.2 to 3.4.
* Updated `test/test` script to reflect these changes.